### PR TITLE
refactor: 服务端与客户端间的序列化

### DIFF
--- a/build-number.properties
+++ b/build-number.properties
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License along
 # with Fhraise. If not, see <https://www.gnu.org/licenses/>.
 #
-buildNumber=50
+buildNumber=51

--- a/compose-app/src/commonMain/kotlin/xyz/xfqlittlefan/fhraise/data/components/root/SignInComponent.kt
+++ b/compose-app/src/commonMain/kotlin/xyz/xfqlittlefan/fhraise/data/components/root/SignInComponent.kt
@@ -124,11 +124,12 @@ interface SignInComponent : AppComponentContext {
                 client.post(Api.Auth.Type.Request(credentialType, this)) {
                     contentType(ContentType.Application.Cbor)
                     setBody(Api.Auth.Type.Request.RequestBody(credential))
-                }.body<Api.Auth.Type.Request.ResponseBody.Success>()
+                }.body<Api.Auth.Type.Request.ResponseBody>()
             }.getOrElse {
                 it.printStackTrace()
                 null
             }?.let {
+                if (it !is Api.Auth.Type.Request.ResponseBody.Success) return@let false
                 verifyingToken = it.token
                 otp = if (it.otpNeeded) "" else null
                 true
@@ -146,11 +147,12 @@ interface SignInComponent : AppComponentContext {
                                 Api.Auth.Type.Verify.RequestBody.Verification(verification, otp)
                             )
                         )
-                    }.body<Api.Auth.Type.Verify.ResponseBody.Success>()
+                    }.body<Api.Auth.Type.Verify.ResponseBody>()
                 }.getOrElse {
                     it.printStackTrace()
                     null
                 }?.let {
+                    if (it !is Api.Auth.Type.Verify.ResponseBody.Success) return@let null
                     verifyingToken = null
                     it.tokenPair
                 }

--- a/server/src/main/kotlin/api/Auth.kt
+++ b/server/src/main/kotlin/api/Auth.kt
@@ -141,12 +141,12 @@ private fun Route.apiAuthRequest() = rateLimit(rateLimitName) {
         val requestId = call.callId
 
         if (requestId == null) {
-            call.respond(Api.Auth.Type.Request.ResponseBody.Failure)
+            call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.Failure)
             return@post
         }
 
         if (!req.parent.validate(body.credential)) {
-            call.respond(Api.Auth.Type.Request.ResponseBody.InvalidCredential)
+            call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.InvalidCredential)
             return@post
         }
 
@@ -162,24 +162,24 @@ private fun Route.apiAuthRequest() = rateLimit(rateLimitName) {
                 val code = appDatabase.queryOrGenerateVerificationCode(application, token.hashCode())
 
                 if (body.dry) {
-                    call.respond(Api.Auth.Type.Request.ResponseBody.Success(token))
+                    call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.Success(token))
                     return@post
                 }
 
                 if (sendVerificationCode(req, user, code.code)) {
-                    call.respond(Api.Auth.Type.Request.ResponseBody.Success(token))
+                    call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.Success(token))
                 } else {
-                    call.respond(Api.Auth.Type.Request.ResponseBody.Failure)
+                    call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.Failure)
                 }
             }
 
             Face -> {
                 // TODO
-                call.respond(Api.Auth.Type.Request.ResponseBody.Failure)
+                call.respondRequestResult(Api.Auth.Type.Request.ResponseBody.Failure)
             }
 
 
-            Password -> call.respond(
+            Password -> call.respondRequestResult(
                 Api.Auth.Type.Request.ResponseBody.Success(token, user.totp == true)
             )
         }
@@ -190,13 +190,13 @@ private fun Route.apiAuthVerify() = post<Api.Auth.Type.Verify> { req ->
     val body = call.receive<Api.Auth.Type.Verify.RequestBody>()
 
     val token = verifiedJwtOrNull(req.token)?.decodedPayloadOrNull<AuthProcessToken>() ?: run {
-        call.respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+        call.respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
         return@post
     }
 
     when (token.type) {
         FhraiseToken, QrCode, SmsCode, EmailCode -> call.respondCodeVerificationResult(token, req, body)
-        Face -> call.respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+        Face -> call.respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
         Password -> call.respondPasswordVerificationResult(token, req, body)
     }
 }
@@ -223,13 +223,13 @@ private suspend fun RoutingCall.respondCodeVerificationResult(
                 if (userNeedsUpdate) user.update()
 
                 exchangeToken(user.id!!)?.let {
-                    respond(Api.Auth.Type.Verify.ResponseBody.Success(it))
-                } ?: respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+                    respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Success(it))
+                } ?: respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
             },
-            onFailure = { respond(Api.Auth.Type.Verify.ResponseBody.Failure) },
+            onFailure = { respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure) },
         )
     } else {
-        respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+        respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
     }
 }
 
@@ -237,7 +237,7 @@ private suspend fun RoutingCall.respondPasswordVerificationResult(
     token: AuthProcessToken, request: Api.Auth.Type.Verify, body: Api.Auth.Type.Verify.RequestBody
 ) {
     val user = getUser(request.parent.credentialType provide token.credential) ?: run {
-        respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+        respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
         return
     }
 
@@ -246,8 +246,8 @@ private suspend fun RoutingCall.respondPasswordVerificationResult(
     }
 
     keycloakClient.getTokensByPassword(authClientId, authClientSecret, user.username!!, body.verification)?.let {
-        respond(Api.Auth.Type.Verify.ResponseBody.Success(JwtTokenPair(it.accessToken, it.refreshToken)))
-    } ?: respond(Api.Auth.Type.Verify.ResponseBody.Failure)
+        respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Success(JwtTokenPair(it.accessToken, it.refreshToken)))
+    } ?: respondVerifyResult(Api.Auth.Type.Verify.ResponseBody.Failure)
 }
 
 private fun Api.Auth.Type.validate(credential: String) = when (credentialType) {
@@ -298,3 +298,11 @@ private data class AuthProcessToken(
     @SerialName("typ") val type: Api.Auth.Type.Request.VerificationType,
     @SerialName("crd") val credential: String
 )
+
+private suspend fun RoutingCall.respondRequestResult(result: Api.Auth.Type.Request.ResponseBody) {
+    respond<Api.Auth.Type.Request.ResponseBody>(result)
+}
+
+private suspend fun RoutingCall.respondVerifyResult(result: Api.Auth.Type.Verify.ResponseBody) {
+    respond<Api.Auth.Type.Verify.ResponseBody>(result)
+}


### PR DESCRIPTION
我曾经认为 kotlinx-serialization 不支持反序列化密封类，于是采用了一种不那么好的解决方案。事实上，它支持这项功能，只不过需要在序列化时指定需要序列化的类型。

```kt
@Serializable
sealed class ResponseBody {
    @Serializable
    data class Success(val token: String, val otpNeeded: Boolean = false) : ResponseBody()

    @Serializable
    data object InvalidCredential : ResponseBody()

    @Serializable
    data object Failure : ResponseBody()
}
```

这个密封类的 `Success` 数据类在 Ktor 中可以使用以下方法序列化为 `ResponseBody` 类型：

```kt
call.respond<ResponseBody>(ResponseBody.Success("token"))
```

这样一来，就有如下方法：

```kt
val body = response.body<ResponseBody>()

body is ResponseBody.Success
```